### PR TITLE
Moving librosa and scipy to optional install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ A collection of audio-focused loss functions in PyTorch.
 pip install auraloss
 ```
 
+If you want to use `MelSTFTLoss()` or `FIRFilter()` you will need to specify the extra install (librosa and scipy).
+
+```
+pip install auraloss[all]
+```
+
 ## Usage
 
 ```python

--- a/auraloss/freq.py
+++ b/auraloss/freq.py
@@ -1,6 +1,5 @@
 import torch
 import numpy as np
-import librosa.filters
 from .utils import apply_reduction
 
 from .perceptual import SumAndDifference, FIRFilter
@@ -132,16 +131,23 @@ class STFTLoss(torch.nn.Module):
         self.linstft = STFTMagnitudeLoss(log=False, reduction=reduction)
 
         # setup mel filterbank
-        if self.scale == "mel":
-            assert sample_rate != None  # Must set sample rate to use mel scale
-            assert n_bins <= fft_size  # Must be more FFT bins than Mel bins
-            fb = librosa.filters.mel(sample_rate, fft_size, n_mels=n_bins)
-            self.fb = torch.tensor(fb).unsqueeze(0)
-        elif self.scale == "chroma":
-            assert sample_rate != None  # Must set sample rate to use chroma scale
-            assert n_bins <= fft_size  # Must be more FFT bins than chroma bins
-            fb = librosa.filters.chroma(sample_rate, fft_size, n_chroma=n_bins)
-            self.fb = torch.tensor(fb).unsqueeze(0)
+        if scale is not None:
+
+            import librosa.filters
+
+            if self.scale == "mel":
+                assert sample_rate != None  # Must set sample rate to use mel scale
+                assert n_bins <= fft_size  # Must be more FFT bins than Mel bins
+                fb = librosa.filters.mel(sample_rate, fft_size, n_mels=n_bins)
+                self.fb = torch.tensor(fb).unsqueeze(0)
+
+            elif self.scale == "chroma":
+                assert sample_rate != None  # Must set sample rate to use chroma scale
+                assert n_bins <= fft_size  # Must be more FFT bins than chroma bins
+                fb = librosa.filters.chroma(sample_rate, fft_size, n_chroma=n_bins)
+                self.fb = torch.tensor(fb).unsqueeze(0)
+            else:
+                raise ValueError(f"Invalid scale: {self.scale}. Must be 'mel' or 'chroma'.")
 
         if scale is not None and device is not None:
             self.fb = self.fb.to(self.device)  # move filterbank to device

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -1,6 +1,5 @@
 import torch
 import numpy as np
-import scipy.signal
 
 
 class SumAndDifference(torch.nn.Module):
@@ -64,6 +63,8 @@ class FIRFilter(torch.nn.Module):
         self.fs = fs
         self.ntaps = ntaps
         self.plot = plot
+
+        import scipy.signal
 
         if ntaps % 2 == 0:
             raise ValueError(f"ntaps must be odd (ntaps={ntaps}).")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auraloss"
-version = "0.2.2"
+version = "0.3.0"
 description = "Collection of audio-focused loss functions in PyTorch."
 authors = [
     { name = "Christian Steinmetz" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,11 @@ authors = [
     { name = "Christian Steinmetz" },
     { email = "c.j.steinmetz@qmul.ac.uk" },
 ]
+dependencies = ["torch", "numpy"]
 
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["torch", "scipy", "numpy", "librosa", "matplotlib"]
+requires = ["setuptools"]
+
+[project.optional-dependencies]
+all = ["matplotlib", "librosa", "scipy", "scipy"]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ URL = "https://github.com/csteinmetz1/auraloss"
 EMAIL = "c.j.steinmetz@qmul.ac.uk"
 AUTHOR = "Christian Steinmetz"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.2.2"
+VERSION = "0.3.0"
 
 HERE = Path(__file__).parent
 
@@ -31,8 +31,8 @@ setup(
     python_requires=REQUIRES_PYTHON,
     url=URL,
     packages=["auraloss"],
-    install_requires=["torch", "scipy", "numpy", "librosa", "matplotlib"],
-    extras_require={"test": ["resampy"]},
+    install_requires=["torch", "numpy"],
+    extras_require={"test": ["resampy"], "all": ["matplotlib",  "librosa", "scipy"]},
     include_package_data=True,
     license="Apache License 2.0",
     classifiers=[

--- a/tests/adv_test.py
+++ b/tests/adv_test.py
@@ -1,6 +1,7 @@
 import torch
 import auraloss
 
+
 input = torch.rand(8, 2, 44100)
 target = torch.rand(8, 2, 44100)
 

--- a/tests/extras_test.py
+++ b/tests/extras_test.py
@@ -1,0 +1,19 @@
+import torch
+import auraloss
+
+pred = torch.rand(8, 2, 44100)
+target = torch.rand(8, 2, 44100)
+
+
+
+# test MelSTFT
+loss = auraloss.freq.MelSTFTLoss(44100)
+res = loss(pred, target)
+print(res, res.shape)
+assert res is not None
+
+# test MelSTFT with no reduction
+loss = auraloss.freq.MelSTFTLoss(44100, reduction="none")
+res = loss(pred, target)
+print(res.shape)
+assert len(res) > 1

--- a/tests/stft_test.py
+++ b/tests/stft_test.py
@@ -16,18 +16,6 @@ res = loss(pred, target)
 print(res, res.shape)
 assert res is not None
 
-# test MelSTFT
-loss = auraloss.freq.MelSTFTLoss(44100)
-res = loss(pred, target)
-print(res, res.shape)
-assert res is not None
-
-# test MelSTFT with no reduction
-loss = auraloss.freq.MelSTFTLoss(44100, reduction="none")
-res = loss(pred, target)
-print(res.shape)
-assert len(res) > 1
-
 # test difference weights
 loss = auraloss.freq.STFTLoss(w_log_mag=1.0, w_lin_mag=0.0, w_sc=1.0, reduction="mean")
 res = loss(pred, target)


### PR DESCRIPTION
This could result in minor breaking changes for some users who are using melspectrogram-based losses or the FIR filter. However, this is likely a very small number of users and the there will be benefits to removing librosa which can cause issues on install on various platforms. 