### PR TITLE
[cm] Fix DCLoss and refactor ESRLoss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ lightning_logs/
 
 test-env/
 *.wav
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,3 @@ lightning_logs/
 
 test-env/
 *.wav
-.idea/

--- a/auraloss/time.py
+++ b/auraloss/time.py
@@ -53,7 +53,7 @@ class DCLoss(torch.nn.Module):
         self.reduction = reduction
 
     def forward(self, input: T, target: T) -> T:
-        num = ((target - input) ** 2).mean(dim=-1)
+        num = (target - input).mean(dim=-1) ** 2
         denom = (target ** 2).mean(dim=-1) + self.eps
         losses = num / denom
         losses = apply_reduction(losses, self.reduction)


### PR DESCRIPTION
This PR refactors the DCLoss and ESRLoss to include an eps term to prevent divide by zero errors on silent signals.
It also adds type hinting, removes unnecessary abs() calls, and breaks the logic down into numerator and denominator.

Finally, the current DCLoss denominator term is squared after the mean is taken, but the mathematical notation in the paper implies the opposite should be done. This agrees with the author of the paper's source code where the denominator is mean energy, but more confusingly, their implementation of the numerator is very different:

```
loss = tr.pow(tr.add(tr.mean(target, 0), -tr.mean(output, 0)), 2)
loss = tr.mean(loss)
energy = tr.mean(tr.pow(target, 2)) + self.epsilon
loss = tr.div(loss, energy)
return loss
```

I believe this PR should exhibit the correct behavior now, but curious what your thoughts are.
