### PR TITLE
Butterworth filtering

### DIFF
--- a/auraloss/freq.py
+++ b/auraloss/freq.py
@@ -90,6 +90,7 @@ class STFTLoss(torch.nn.Module):
             [‘lowpass’, ‘highpass’, ‘bandpass’, ‘bandstop’]
             Default: None
         filter_order (int, optional) The order of the filter for filter_weighting. Default: None
+        filter_ntaps (int, optional) Number of ntaps for FIRfilter
 
     Returns:
         loss:
@@ -121,7 +122,8 @@ class STFTLoss(torch.nn.Module):
         device: Any = None,
         filter_freq: Any = None,
         filter_type: str = None,
-        filter_order: int = None
+        filter_order: int = None,
+        filter_ntaps: int = 101
     ):
         super().__init__()
         self.fft_size = fft_size
@@ -146,6 +148,7 @@ class STFTLoss(torch.nn.Module):
         self.filter_freq = filter_freq
         self.filter_type = filter_type
         self.filter_order = filter_order
+        self.filter_ntaps = filter_ntaps
 
         self.spectralconv = SpectralConvergenceLoss()
         self.logstft = STFTMagnitudeLoss(
@@ -195,7 +198,7 @@ class STFTLoss(torch.nn.Module):
                 raise ValueError(
                     f"`sample_rate` must be supplied when `perceptual_weighting = True`."
                 )
-            self.prefilter = FIRFilter(filter_type="aw", fs=sample_rate)
+            self.prefilter = FIRFilter(filter_type="aw", fs=sample_rate, ntaps=self.filter_ntaps)
 
         if self.filter_weighting:
             if sample_rate is None:
@@ -206,7 +209,7 @@ class STFTLoss(torch.nn.Module):
                 raise ValueError(
                     f"`filter_order`, `filter_freq`, and `filter_type` must be supplied when `filter_weighting = True`."
                 )
-            self.prefilter = FIRFilter(filter_type="butter", fs=sample_rate, butter_order=self.filter_order, butter_freq=self.filter_freq, butter_filter_type=self.filter_type)
+            self.prefilter = FIRFilter(filter_type="butter", fs=sample_rate, butter_order=self.filter_order, butter_freq=self.filter_freq, butter_filter_type=self.filter_type, ntaps=self.filter_ntaps)
 
     def stft(self, x):
         """Perform STFT.

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,10 +118,10 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, fs=fs, analog=True))
-
+            # filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            b, a = scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=False, output="ba", fs=fs)
             # convert analog filter to digital filter
-            b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)
+            # b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)
 
             # compute the digital filter frequency response
             w_iir, h_iir = scipy.signal.freqz(b, a, worN=512, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -117,11 +117,8 @@ class FIRFilter(torch.nn.Module):
                 from .plotting import compare_filters
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
-            # Define butter filter
-            # filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            # Define digital butter filter
             b, a = scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=False, output="ba", fs=fs)
-            # convert analog filter to digital filter
-            # b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)
 
             # compute the digital filter frequency response
             w_iir, h_iir = scipy.signal.freqz(b, a, worN=512, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,7 +118,7 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = signal.lti(*signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            filts = scipy.signal.lti(*signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
 
             # convert analog filter to digital filter
             b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,7 +118,7 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, fs=fs, analog=True))
 
             # convert analog filter to digital filter
             b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,7 +118,7 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = scipy.signal.lti(*signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
 
             # convert analog filter to digital filter
             b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)


### PR DESCRIPTION
Adding capability to use custom filters via scipy butter filter in lieu of perceptual weighting. Added kwargs:

- filter_weighting (bool)
- filter_freq (int)
- filter_type (str)
- filter_order (int)
- filter_ntaps (int)

Added filter_ntaps as a variable kwarg to increase fidelity of FIR Filter.

Also added comments explaining new kwargs. Have tested models using these updated filtered loss functions and looks to be working as expected without changing existing functionality. Eventually might be nice to replace `perceptual_weighting` and `filter_weighting` bool kwargs with a unified kwarg to switch between any of them but didn't want to mess up current use.