### PR TITLE
Fir filter input

### DIFF
--- a/auraloss/freq.py
+++ b/auraloss/freq.py
@@ -2,7 +2,7 @@ import torch
 import numpy as np
 from typing import List, Any
 
-from .utils import apply_reduction
+from .utils import apply_reduction, FIRSequential
 from .perceptual import SumAndDifference, FIRFilter
 
 
@@ -187,7 +187,7 @@ class STFTLoss(torch.nn.Module):
             if self.prefilter is None:
                 self.prefilter = FIRFilter(filter_type="aw", fs=sample_rate)
             else:
-                self.prefilter = torch.nn.Sequential(FIRFilter(filter_type="aw", fs=sample_rate), self.prefilter)
+                self.prefilter = FIRSequential(FIRFilter(filter_type="aw", fs=sample_rate), self.prefilter)
 
     def stft(self, x):
         """Perform STFT.

--- a/auraloss/freq.py
+++ b/auraloss/freq.py
@@ -84,6 +84,7 @@ class STFTLoss(torch.nn.Module):
             Default: 'mean'
         mag_distance (str, optional): Distance function ["L1", "L2"] for the magnitude loss terms.
         device (str, optional): Place the filterbanks on specified device. Default: None
+        prefilter (FIRFilter, optional): apply customizable FIRFilter constructed by auraloss.perceptual.FIRFilter to STFT loss. Default: None
 
     Returns:
         loss:
@@ -112,6 +113,7 @@ class STFTLoss(torch.nn.Module):
         reduction: str = "mean",
         mag_distance: str = "L1",
         device: Any = None,
+        prefilter: FIRFilter = None,
     ):
         super().__init__()
         self.fft_size = fft_size
@@ -132,6 +134,7 @@ class STFTLoss(torch.nn.Module):
         self.reduction = reduction
         self.mag_distance = mag_distance
         self.device = device
+        self.prefilter = prefilter
 
         self.spectralconv = SpectralConvergenceLoss()
         self.logstft = STFTMagnitudeLoss(
@@ -181,7 +184,10 @@ class STFTLoss(torch.nn.Module):
                 raise ValueError(
                     f"`sample_rate` must be supplied when `perceptual_weighting = True`."
                 )
-            self.prefilter = FIRFilter(filter_type="aw", fs=sample_rate)
+            if self.prefilter is None:
+                self.prefilter = FIRFilter(filter_type="aw", fs=sample_rate)
+            else:
+                self.prefilter = torch.nn.Sequential(FIRFilter(filter_type="aw", fs=sample_rate), self.prefilter)
 
     def stft(self, x):
         """Perform STFT.
@@ -209,7 +215,7 @@ class STFTLoss(torch.nn.Module):
     def forward(self, input: torch.Tensor, target: torch.Tensor):
         bs, chs, seq_len = input.size()
 
-        if self.perceptual_weighting:  # apply optional A-weighting via FIR filter
+        if self.prefilter is not None:  # apply prefilter
             # since FIRFilter only support mono audio we will move channels to batch dim
             input = input.view(bs * chs, 1, -1)
             target = target.view(bs * chs, 1, -1)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,10 +118,10 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, fs=fs, analog=True))
-
+            # filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            b, a = scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=False, output="ba", fs=fs)
             # convert analog filter to digital filter
-            b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)
+            # b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)
 
             # compute the digital filter frequency response
             w_iir, h_iir = scipy.signal.freqz(b, a, worN=512, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -117,11 +117,8 @@ class FIRFilter(torch.nn.Module):
                 from .plotting import compare_filters
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
-            # Define butter filter
-            # filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            # Define digital butter filter
             b, a = scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=False, output="ba", fs=fs)
-            # convert analog filter to digital filter
-            # b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)
 
             # compute the digital filter frequency response
             w_iir, h_iir = scipy.signal.freqz(b, a, worN=512, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,7 +118,7 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = signal.lti(*signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            filts = scipy.signal.lti(*signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
 
             # convert analog filter to digital filter
             b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,7 +118,7 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, fs=fs, analog=True))
 
             # convert analog filter to digital filter
             b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)

--- a/auraloss/perceptual.py
+++ b/auraloss/perceptual.py
@@ -118,7 +118,7 @@ class FIRFilter(torch.nn.Module):
                 compare_filters(b, a, taps, fs=fs)
         elif filter_type == "butter":
             # Define butter filter
-            filts = scipy.signal.lti(*signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
+            filts = scipy.signal.lti(*scipy.signal.butter(self.butter_order, self.butter_freq, self.butter_filter_type, analog=True))
 
             # convert analog filter to digital filter
             b, a = scipy.signal.bilinear(filts.num, filts.den, fs=fs)

--- a/auraloss/utils.py
+++ b/auraloss/utils.py
@@ -11,6 +11,6 @@ def apply_reduction(losses, reduction="none"):
 
 class FIRSequential(torch.nn.Sequential):
   def forward(self, *inputs):
-    for module in self._modules.values:
+    for module in self._modules.values():
       inputs = module(*inputs)
     return inputs

--- a/auraloss/utils.py
+++ b/auraloss/utils.py
@@ -10,8 +10,6 @@ def apply_reduction(losses, reduction="none"):
     return losses
 
 class FIRSequential(torch.nn.Sequential):
-  def __init__(self):
-    super().__init__()
   def forward(self, *inputs):
     for module in self._modules.values:
       inputs = module(*inputs)

--- a/auraloss/utils.py
+++ b/auraloss/utils.py
@@ -8,3 +8,11 @@ def apply_reduction(losses, reduction="none"):
     elif reduction == "sum":
         losses = losses.sum()
     return losses
+
+class FIRSequential(torch.nn.Sequential):
+  def __init__(self):
+    super().__init__()
+  def forward(self, *inputs):
+    for module in self._modules.values:
+      inputs = module(*inputs)
+    return inputs


### PR DESCRIPTION
In this PR I add optional FIRFilter input to STFTLoss, this filter automatically fills self.prefilter if available and sets it to None if not provided. If only perceptual_weighting flag is set, self.prefilter is set with internally constructed FIRFilter. 

If both an external FIRFilter is provided and perceptual_weighting flag is set, an nn.Sequential variation (that allows for two inputs) is constructed to run both filters sequentially.

Tested on some audio input and appears to be working as expected. Below are some spectrograms of the different variations.

No Filter:
<img width="596" alt="audio_no_filter" src="https://github.com/csteinmetz1/auraloss/assets/19558986/c9560abd-4e95-43fa-9f65-be2f8bb07361">

Only Perceptual Weighting:
<img width="620" alt="audio_only_percep_weight" src="https://github.com/csteinmetz1/auraloss/assets/19558986/51612fca-afc5-403c-a753-ff226a3548bb">

Only External 4.5k Lowpass Filter:
<img width="598" alt="audio_only_4k_lowpass" src="https://github.com/csteinmetz1/auraloss/assets/19558986/8f7e5e60-5bd9-46a9-b602-76a0bf22b741">

Both Filters:
<img width="587" alt="audio_percep_weight_and_4k_lowpass" src="https://github.com/csteinmetz1/auraloss/assets/19558986/266b1123-f7cc-4b6d-9e1d-427ed00add76">

Also included are the changes to `auraloss.perceptual.FIRFilter` which allows for for butterworth filter construction and a FIRSequential class in `auraloss.utils` that inherits from nn.Sequential and allows for multiple inputs.

I haven't tried using this branch in a model yet but it has worked returning losses as expected in my testing of just this repo. 
