### PR TITLE
Change magnitude calculation in STFTLoss for better interpretability of the eps parameter

### DIFF
--- a/auraloss/freq.py
+++ b/auraloss/freq.py
@@ -200,9 +200,7 @@ class STFTLoss(torch.nn.Module):
             self.window,
             return_complex=True,
         )
-        x_mag = torch.sqrt(
-            torch.clamp((x_stft.real**2) + (x_stft.imag**2), min=self.eps)
-        )
+        x_mag = torch.clamp(torch.abs(x_stft), min=self.eps)
         x_phs = torch.angle(x_stft)
         return x_mag, x_phs
 


### PR DESCRIPTION
Previously, small values were clamped inside a `torch.sqrt`, so that the smallest possible values were `sqrt(eps)` instead of `eps`. For example, the default `eps=1e-8` led to a smallest value of `1e-4`.