### PR TITLE
Enable CI for pull requests; fix project setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: pytest
 
-on: [push]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0' # at 00:00 every Sunday
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,4 @@
-[project]
-name = "auraloss"
-version = "0.4.0"
-description = "Collection of audio-focused loss functions in PyTorch."
-authors = [
-    { name = "Christian Steinmetz" },
-    { email = "c.j.steinmetz@qmul.ac.uk" },
-]
-dependencies = ["torch", "numpy"]
-
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel", "attrs"]
 build-backend = "setuptools.build_meta"
-
-[project.optional-dependencies]
-all = ["matplotlib", "librosa", "scipy", "scipy"]


### PR DESCRIPTION
The goal of this PR is to enable the CI checks for pull requests to allow adding further checks (type checker, black) in follow-up PRs as a preparation for #77.

While doing so, I've also added a weekly re-run of the CI. This can be useful to see if there are regressions introduced from changes in upstream dependencies (because the CI strategy of this repo is not to fully pin the dependencies, but rather test against a "moving target").

Enabling the checks however revealed that the CI is currently broken, due to a violation in the `pyproject.toml` vs `setup.py` setup. Basically executing `pip install ".[all]"` fails with modern versions of pip with errors like these:

```
********************************************************************************
The following seems to be defined outside of `pyproject.toml`:

`classifiers = ['License :: OSI Approved :: Apache Software License', 'Topic :: Multimedia :: Sound/Audio', 'Topic :: Scientific/Engineering']`

According to the spec (see the link below), however, setuptools CANNOT
consider this value unless `classifiers` is listed as `dynamic`.

https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table

To prevent this problem, you can list `classifiers` under `dynamic` or alternatively
remove the `[project]` table from your file and rely entirely on other means of
configuration.
********************************************************************************
```

Basically pip is complaining about the redundancy that currently exists between the information in the `pyproject.toml` vs `setup.py`.

I have resolved this issues by removing the information from the `pyproject.toml` -- note that it is fully redundant to the information specified in `setup.py`.

An alternative would be to resolve the redundancy towards `pyproject.toml` instead, i.e., basically remove the `setup.py` altogether. This should be feasible as well. If you prefer, I could also try to resolve the redundancy in this direction.